### PR TITLE
Hotfix Navbar dark div issue

### DIFF
--- a/components/common/header.tsx
+++ b/components/common/header.tsx
@@ -194,7 +194,7 @@ export default function HelixQueHeader({ className }: HelixQueHeaderProps) {
           <>
             {/* Overlay */}
             <motion.div 
-              className="fixed inset-0 top-16 z-40 bg-black/20 md:hidden"
+              className="fixed inset-0 top-16 z-40 md:hidden"
               onClick={() => setIsMenuOpen(false)}
               aria-hidden="true"
               initial={{ opacity: 0 }}


### PR DESCRIPTION
The issue has main root cause of this :
```
<motion.div 
              className="fixed inset-0 top-16 z-40 <has the dark bg color> md:hidden"
              onClick={() => setIsMenuOpen(false)}
              aria-hidden="true"
              initial={{ opacity: 0 }}
              animate={{ opacity: 1 }}
              exit={{ opacity: 0 }}
              transition={{ duration: 0.15 }} 
/>
```