### PR TITLE
Fixed the g overlapping

### DIFF
--- a/components/sections/hero/index.tsx
+++ b/components/sections/hero/index.tsx
@@ -32,10 +32,9 @@ export const HeroSection = () => {
         <div className="relative z-1 mx-auto max-w-3xl text-center">
           <h1 className="leading-tighter font-gilroy max-w-2xl mx-auto bg-gradient-to-b from-gray-900/90 via-gray-800 to-gray-700/80 dark:from-white/80 dark:via-white dark:to-white/60 bg-clip-text text-4xl sm:text-5xl md:text-5xl font-semibold tracking-tight text-pretty text-transparent lg:leading-[1.1] xl:text-6xl/[4rem] xl:tracking-tighter">
             Professional networking for
-            <br/>
           
             <LayoutGroup>
-              <motion.span className="relative translate-x-0 flex gap-2 justify-center flex-wrap items-center" layout>
+              <motion.span className="mt-2 relative translate-x-0 flex gap-2 justify-center flex-wrap items-center" layout>
                 <TextRotate
                   texts={words}
                   mainClassName="text-white dark:text-black px-3 bg-black dark:bg-white overflow-hidden py-1.5 justify-center rounded-lg"


### PR DESCRIPTION
- Fixed the g overlapping onto the bottom element.
- Fixed image attached below.
<img width="256" height="175" alt="image" src="https://github.com/user-attachments/assets/acdbe81f-f0e6-4280-865f-295a6ddc89c8" />

Resolves #91 
Cheers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the hero header layout for a cleaner, continuous tagline by removing an extra line break.
  * Adjusted vertical spacing around the rotating text to improve visual balance and readability.
  * Polished spacing without altering behavior or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->