### PR TITLE
Add SECURITY.md with Responsible Disclosure and Reporting Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+Thank you for your interest in keeping Helixque safe. This document explains how to report security vulnerabilities and what to expect after you report one.
+
+## Supported Versions
+
+We actively maintain the `main` branch. For released versions, we support the latest published release and the previous minor release. If you believe a vulnerability affects an unsupported version, please still report it — we'll advise on mitigation.
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please report it privately to the maintainers so we can investigate and remediate before public disclosure.
+
+Preferred contact:
+
+- Email: security@helixque.com (If this inbox is unavailable, open an issue and mark it `security` and we will follow up privately.)
+
+If email is not an option, you may open a GitHub issue and request a private discussion by including the word `security` in the title. Do NOT include exploit code or sensitive details in a public issue.
+
+## What to include
+
+When reporting, please include:
+
+- A short, clear description of the issue
+- Versions and environment where the issue was observed
+- Step-by-step reproduction instructions or a PoC (encrypted if sensitive)
+- Any suggested mitigation or steps we should take to reproduce
+
+## Optional: Encrypted Reports
+
+If you prefer to send sensitive information (for example, exploit code or credentials), encrypt it with the maintainer's PGP key. If a PGP key is not available, contact us by email and we will provide a secure method for sharing details.
+
+## Response Policy
+
+- Acknowledgement: We will acknowledge receipt within 5 business days.
+- Triage & Fix: We aim to triage critical reports within 7 business days and provide a remediation timeline or workaround. Complex issues may take longer; we will provide updates.
+- Coordinated Disclosure: We appreciate coordinated disclosure. We will not publicly disclose the issue until a fix or mitigation is available, unless required by law.
+- Credit: If you would like credit for the report, state your preferred name or handle. We will honor requests to remain anonymous.
+
+## Security Fixes and Releases
+
+We will prioritize fixes based on severity. For fixes that affect released versions, we will publish patches or releases and document the CVE or advisory if applicable.
+
+## Legal
+
+We will not pursue legal action against good-faith security researchers following this policy. Avoid non-consensual testing of user data, account takeover, or denial-of-service testing unless you have explicit permission.
+
+## Thank you
+
+Thank you for helping us keep the project and its users safe. If you have questions about this policy, contact us at the address above.


### PR DESCRIPTION
### Description

This PR adds a comprehensive `SECURITY.md` file to the root of the repository, outlining the project’s security policy for responsibly reporting vulnerabilities.

The document includes:

* Supported versions and maintenance policy
* How to report security issues privately via email or GitHub
* Information to include when reporting vulnerabilities
* Optional encrypted reporting instructions
* Response and triage timelines
* Coordinated disclosure guidelines
* Legal safe harbor for good-faith security researchers

Adding this file improves transparency, encourages responsible vulnerability disclosure, and helps maintain the security and trustworthiness of the Helixque project.

Fixes #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a SECURITY policy document detailing supported versions, private vulnerability reporting procedures (with optional encryption and GitHub fallback), required report contents, response timelines (acknowledgement, triage, fixes, disclosure), fix/release handling, legal stance, and contact information.
  * Provides a clear, centralized process for submitting and coordinating security issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->