### PR TITLE
fix: improve announcement page alignment and spacing

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -48,13 +48,13 @@ export default function AnnouncementsPage() {
   return (
     <div className="min-h-screen bg-background relative">
       {/* Page Title Section */}
-      <div className="pt-8 pb-16">
-        <div className="max-w-5xl mx-auto px-6 lg:px-10">
+      <div className="pt-8 pb-12 sm:pb-16">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-10">
           <div className="text-center">
-            <h1 className="text-foreground mt-8 text-4xl text-[clamp(40px,10vw,44px)] leading-[1.2] font-bold tracking-tighter text-balance sm:text-5xl">
+            <h1 className="text-foreground mt-6 sm:mt-8 text-3xl sm:text-4xl text-[clamp(32px,8vw,44px)] leading-[1.2] font-bold tracking-tighter text-balance lg:text-5xl">
               Announcements
             </h1>
-            <p className="text-muted-foreground text-base tracking-tight mt-6 max-w-2xl mx-auto sm:text-lg">
+            <p className="text-muted-foreground text-sm sm:text-base tracking-tight mt-4 sm:mt-6 max-w-2xl mx-auto lg:text-lg">
               Stay informed with the latest updates, important notices, and announcements from HelixQue.
             </p>
           </div>
@@ -62,24 +62,28 @@ export default function AnnouncementsPage() {
       </div>
 
       {/* Timeline */}
-      <div className="max-w-5xl mx-auto px-6 lg:px-10 pt-16">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-10 pt-12 sm:pt-16 pb-16 sm:pb-20">
         <div className="relative">
-          {sortedAnnouncements.map((announcement) => {
+          {/* Vertical timeline line - positioned outside the loop for better alignment */}
+          <div className="hidden md:block absolute left-48 top-0 w-px bg-border" style={{ height: 'calc(100% - 2rem)' }} />
+          
+          {sortedAnnouncements.map((announcement, index) => {
             const MDX = announcement.data.body
             const date = new Date(announcement.data.date)
             const formattedDate = formatDate(date)
 
             return (
-              <div key={announcement.url} className="relative">
-                <div className="flex flex-col md:flex-row gap-y-6">
+              <div key={announcement.url} className="relative mb-12 sm:mb-16 last:mb-0">
+                <div className="flex flex-col md:flex-row gap-y-4 sm:gap-y-6">
+                  {/* Left side - Date and Priority */}
                   <div className="md:w-48 flex-shrink-0">
-                    <div className="md:sticky md:top-24 pb-10">
-                      <time className="text-sm font-medium text-muted-foreground block mb-3">
+                    <div className="md:sticky md:top-24 pb-4 sm:pb-6">
+                      <time className="text-xs sm:text-sm font-medium text-muted-foreground block mb-2 sm:mb-3">
                         {formattedDate}
                       </time>
 
                       {announcement.data.priority && (
-                        <div className={`inline-flex relative z-10 items-center justify-center px-3 py-1 text-xs font-medium rounded-full ${getPriorityColor(announcement.data.priority)}`}>
+                        <div className={`inline-flex relative z-10 items-center justify-center px-2 sm:px-3 py-1 text-xs font-medium rounded-full ${getPriorityColor(announcement.data.priority)}`}>
                           {announcement.data.priority.toUpperCase()}
                         </div>
                       )}
@@ -87,27 +91,24 @@ export default function AnnouncementsPage() {
                   </div>
 
                   {/* Right side - Content */}
-                  <div className="flex-1 md:pl-8 relative pb-10">
-                    {/* Vertical timeline line */}
-                    <div className="hidden md:block absolute top-2 left-0 w-px h-full bg-border">
-                      {/* Timeline dot */}
-                      <div className="hidden md:block absolute -translate-x-1/2 size-3 bg-primary rounded-full z-10" />
-                    </div>
+                  <div className="flex-1 md:pl-8 relative">
+                    {/* Timeline dot */}
+                    <div className="hidden md:block absolute -left-4 top-2 w-3 h-3 bg-primary rounded-full z-10 border-2 border-background" />
 
-                    <div className="space-y-6">
-                      <div className="relative z-10 flex flex-col gap-2">
-                        <h2 className="text-2xl font-semibold tracking-tight text-balance">
+                    <div className="space-y-4 sm:space-y-6">
+                      <div className="relative z-10 flex flex-col gap-2 sm:gap-3">
+                        <h2 className="text-xl sm:text-2xl font-semibold tracking-tight text-balance leading-tight">
                           {announcement.data.title}
                         </h2>
 
                         {/* Tags */}
                         {announcement.data.tags &&
                           announcement.data.tags.length > 0 && (
-                            <div className="flex flex-wrap gap-2">
+                            <div className="flex flex-wrap gap-1.5 sm:gap-2 mt-1 sm:mt-2">
                               {announcement.data.tags.map((tag: string) => (
                                 <span
                                   key={tag}
-                                  className="h-6 w-fit px-2 text-xs font-medium bg-muted text-muted-foreground rounded-full border flex items-center justify-center"
+                                  className="h-5 sm:h-6 w-fit px-1.5 sm:px-2 text-xs font-medium bg-muted text-muted-foreground rounded-full border flex items-center justify-center"
                                 >
                                   {tag}
                                 </span>
@@ -115,7 +116,11 @@ export default function AnnouncementsPage() {
                             </div>
                           )}
                       </div>
-                      <div className="prose dark:prose-invert max-w-none prose-headings:scroll-mt-8 prose-headings:font-semibold prose-a:no-underline prose-headings:tracking-tight prose-headings:text-balance prose-p:tracking-tight prose-p:text-balance">
+                      
+                      {/* Content divider */}
+                      <div className="w-full h-px bg-border/50 my-4 sm:my-6" />
+                      
+                      <div className="prose dark:prose-invert max-w-none prose-headings:scroll-mt-8 prose-headings:font-semibold prose-a:no-underline prose-headings:tracking-tight prose-headings:text-balance prose-p:tracking-tight prose-p:text-balance prose-p:leading-relaxed prose-li:leading-relaxed prose-sm sm:prose-base">
                         <MDX />
                       </div>
                     </div>


### PR DESCRIPTION
#90 

- Fix section alignment and spacing issues across all screen sizes
- Enhance responsive design with mobile-first approach
- Add consistent spacing between announcement items
- Improve tag styling and responsive behaviour

Before
<img width="1074" height="374" alt="Screenshot 2025-10-06 at 11 06 29 AM" src="https://github.com/user-attachments/assets/19bb370c-bc2d-447d-b7d4-0db4e6ac7838" />

After the changes 
<img width="1298" height="481" alt="Screenshot 2025-10-06 at 11 09 58 AM" src="https://github.com/user-attachments/assets/8f610a2b-83b4-4b14-827b-84adfb5caafc" />
