### PR TITLE
Changing close (x) at be right aligned.

### DIFF
--- a/components/common/origin-banner-customizable.tsx
+++ b/components/common/origin-banner-customizable.tsx
@@ -19,7 +19,7 @@ export default function OriginBannerCustomizable({
     <div className={cn("relative dark text-foreground px-4 py-2 sm:py-3", className)}>
       <button
         type="button"
-        className="group absolute right-2 top-1/2 -translate-y-1/2 size-8 p-0 hover:bg-transparent cursor-pointer"
+        className="group absolute translate-x-[21px] right-2 top-1/2 -translate-y-1/2 size-8 p-0 hover:bg-transparent cursor-pointer"
         aria-label="Close banner"
         onClick={() => setIsVisible(false)}
       >
@@ -66,5 +66,3 @@ export default function OriginBannerCustomizable({
     </div>
   )
 }
-
-


### PR DESCRIPTION
Summary:

Changing position of close button such that it appears right aligned and not at center(when screen width is low) by changing tailwind class of button in components/common/origin-banner-customizable.tsx

Type of Changes:

Feature addition

UI/UX improvements

Testing Completed:

Tested changes locally

Screenshot
<img width="368" height="381" alt="Screenshot From 2025-10-14 02-27-19" src="https://github.com/user-attachments/assets/46282b4d-37b4-4ca7-8a2d-bee0dd497677" />

Closes issue #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined close button positioning in the origin banner for better alignment and spacing, introducing a subtle horizontal offset.
  - Improves visual balance, reduces overlap with banner content, and provides a more consistent tap/click target across screen sizes.
  - No functional changes; layout and behavior remain the same aside from the updated placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->