### PR TITLE
Right Aligning the button component relative of parent container width.

### DIFF
--- a/components/common/origin-banner-customizable.tsx
+++ b/components/common/origin-banner-customizable.tsx
@@ -19,13 +19,13 @@ export default function OriginBannerCustomizable({
     <div className={cn("relative dark text-foreground px-4 py-2 sm:py-3", className)}>
       <button
         type="button"
-        className="group absolute right-0 top-1/2 -translate-y-1/2 size-4 p-0 hover:bg-transparent cursor-pointer"
+        className="group absolute right-0 top-1/2 -translate-y-1/2 size-8 p-0 hover:bg-transparent cursor-pointer"
         aria-label="Close banner"
         onClick={() => setIsVisible(false)}
       >
         <XIcon
           size={16}
-          className="opacity-60 transition-opacity group-hover:opacity-100"
+          className="opacity-60 translate-x-3 transition-opacity group-hover:opacity-100"
           aria-hidden="true"
         />
       </button>


### PR DESCRIPTION
## 🌟 Pre-submission Checklist

- [x] ⭐ **I have starred both the [HelixQue repo](https://github.com/helixque/helixque) and the [Landing repo](https://github.com/helixque/landing)** (mandatory before contributing)
- [x] 💬 **I am a member of the Discord server**: [Join Here](https://discord.gg/UJfWXRYe)
- [x] 📝 **I have signed up on [helixque.netlify.app](https://helixque.netlify.app/)**
- [x] 🌐 **For landing page changes, I have made updates to [helixque.vercel.app](https://helixque.vercel.app/)**
- [x] 📢 **I have checked the `#pull-request` channel** in Discord to make sure no one else is working on this issue
- [x] 📝 **I have mentioned this PR in the Discord `#pull-request` channel**

***

## Summary

Right aligning close (x) button properly by scaling relative to parent container width.
Also, aligning the XIcon with the button component better in the process.

***

## Type of Changes

- [ ] 🚀 Feature addition
- [x] 🐛 Bug fix
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring
- [x] 🎨 UI/UX improvements
- [ ] ⚡ Performance optimizations
- [x] 📱 Mobile responsiveness
- [ ] ♿ Accessibility improvements
- [ ] Other: _____

***

## Testing Completed

- [x] ✅ Tested changes locally
- [x] 🔧 Backend functionality works properly (if applicable)
- [x] 🎨 Frontend functionality works properly (if applicable)
- [ ] 🌐 WebRTC connections verified (if applicable)
- [x] 📱 Checked on different screen sizes/devices
- [x] 🔄 Tested edge cases (disconnections, reconnections, etc.)
- [ ] 🧪 All existing functionality remains unaffected

***

## Development Setup Verification

- [x] 📦 Dependencies installed for both frontend and backend
- [x] 🚀 Development servers start without errors
- [ ] 🏗️ Code builds successfully

***

## Code Quality

- [x] 📏 Follows existing TypeScript and React patterns
- [x] 📝 Uses meaningful variable and function names
- [x] 💡 Added comments for complex logic
- [x] 🎯 Code is properly formatted
- [x] 🔍 Self-review performed

***

## Related Issues

_Closes #120 

***

## Screenshots/Videos

Intial:
<img width="388" height="697" alt="Screenshot From 2025-10-14 11-26-27" src="https://github.com/user-attachments/assets/5f725960-8a6c-4b58-b87c-7b1684164548" />

Desktop:
<img width="1910" height="966" alt="image" src="https://github.com/user-attachments/assets/36ca458a-11fe-4e58-8825-224e09ab57c3" />

iPad:
<img width="1183" height="822" alt="Screenshot From 2025-10-14 23-43-57" src="https://github.com/user-attachments/assets/11204bca-c044-41fe-886a-33f4f028e6ab" />

***

**Note:** For faster PR review and approval, please stay active in our Discord server!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the close button placement in the customizable origin banner, moving it to the far right for cleaner alignment.
  * Slightly adjusted the icon's horizontal offset for visual balance.
  * Visual size and interaction remain consistent, yielding a tidier banner with an unobtrusive close control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->